### PR TITLE
adds functionality for OR queries #24

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ The `options` object must contain `tableName` for crud operation *if performing 
 | `fields` | `insert`, `update` | Object with field names and values corresponding to the schema provided |  
 | `select` | `select` | array of keys which want to be retrieved, if not present defaults to all columns, *note you can use `'name AS user_name'` to help with clashing column names in case of innerJoin*  |
 | `where` | `select`, `update`, `delete` | object with field names and values that must match by equality (would like inequalities in future) |
+| `or` | `where` | object with multiple field names and/or values where at least one must match by equality. An array can be provided to specify multiple options for one field |
 | `innerJoin` or `leftOuterJoin` | `select` | Allows you to perform an joins of given type on two tables based on two fields. pass an object of the form `{ table1, table2, column1, column2 }`   |
 
 The `query` handler takes options object of the form `{raw: 'SELECT * FROM your_raw_psql' }`.

--- a/lib/sql_gen.js
+++ b/lib/sql_gen.js
@@ -5,17 +5,29 @@ var aguid = require('aguid');
 var mapper = require('./create_table_map.js');
 var utils = require('./utils.js');
 
-
-function paramStr (columns, opts) {
+function paramStr (key, opts) {
   var offset = (opts && opts.offset) || 0;
   var assign = (opts && opts.assign) || false;
 
-  return columns.map(function (k, i) {
-    var suff = '$' + (1 + i + (offset || 0));
-    var pref = assign ? k + '=' : '';
+  var suff = '$' + (1 + (offset || 0));
+  var pref = assign ? key + '=' : '';
 
-    return pref + suff;
+  return pref + suff;
+}
+
+function processOr (where, key, index) {
+  var conds = Object.keys(where[key]);
+  var count = 0;
+  var values = [];
+
+  conds.forEach(function (e, i) {
+    [].concat(where[key][e]).forEach(function (el, ind) {
+      values.push(paramStr(e, {offset: (index + count), assign: true}));
+      count++;
+    });
   });
+
+  return { query: '(' + values.join(' OR ') + ')', valCount: count };
 }
 
 function quote (name) {
@@ -24,8 +36,18 @@ function quote (name) {
 
 function processWhere (where, query, values) {
   var keys = Object.keys(where);
-  var conds = paramStr(keys, { offset: values.length, assign: true });
-  var vals = utils.values(where, keys);
+  var offset = values.length;
+  var conds = keys.map(function (e, i) {
+    if (e.toLowerCase() === 'or') {
+      var orQuery = processOr(where, e, i);
+      offset += orQuery.valCount;
+
+      return orQuery.query;
+    }
+
+    return paramStr(e, { offset: offset + i, assign: true });
+  });
+  var vals = utils.nestedValues(where, keys);
 
   return {
     query: ['WHERE'].concat(conds.join(' AND ')),
@@ -115,7 +137,9 @@ exports.insert = function insert (config, options) {
   var normalColumns = Object.keys(fields);
   var values = utils.values(fields, normalColumns).concat(ids);
   var columns = normalColumns.concat(idFields);
-  var params = paramStr(columns);
+  var params = columns.map(function (e, i) {
+    return paramStr(e, { offset: i })
+  });
   var query = ['INSERT INTO', quote(options.tableName)]
     .concat('(' + columns.join(', ') + ')')
     .concat('VALUES')
@@ -136,7 +160,9 @@ exports.update = function update (_, options) {
   var result;
   var fields = options.fields || {};
   var columns = Object.keys(fields);
-  var conditions = paramStr(columns, { assign: true });
+  var conditions = columns.map(function (e, i) {
+    return paramStr(e, { assign: true, offset: i })
+  });
   var values = utils.values(fields, columns);
   var query = ['UPDATE', quote(options.tableName)]
     .concat('SET')

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -5,6 +5,21 @@ exports.values = function (obj, keys) {
     .map(function (k) { return obj[k] });
 };
 
+function nestedValues (obj) {
+  return Object.keys(obj).map(function (k) {
+    if (typeof obj[k] === 'object') {
+      if (Array.isArray(obj[k])) {
+        return obj[k];
+      };
+      return nestedValues(obj[k]);
+    }
+    return obj[k];
+  }).reduce(function (a, b) {
+    return a.concat(b);
+  }, []);
+}
+
+exports.nestedValues = nestedValues;
 
 function except (fields, obj) {
   var o = {};
@@ -17,7 +32,6 @@ function except (fields, obj) {
 
   return o;
 }
-
 
 exports.except = except;
 

--- a/test/sql_gen.test.js
+++ b/test/sql_gen.test.js
@@ -59,6 +59,38 @@ tape('::select - gen. SQL to select cols from table w/ where', function (t) {
   t.end();
 });
 
+tape('::select - SQL to select w/ where and OR', function (t) {
+  var query = sqlGen.select(null, {
+    tableName: schema.tableName,
+    select: ['email', 'dob'],
+    where: { or: { hello: ['world', 'there'], name: 'john' } }
+  });
+
+  t.equal(
+    query[0],
+    'SELECT email, dob FROM "user_data" WHERE (hello=$1 OR hello=$2 OR name=$3)',
+    'Generate parameterised query'
+  );
+  t.deepEqual(query[1], ['world', 'there', 'john'], 'Generate values for parameterised query');
+  t.end();
+});
+
+tape('::select - SQL to select w/ where, AND and OR', function (t) {
+  var query = sqlGen.select(null, {
+    tableName: schema.tableName,
+    select: ['email', 'dob'],
+    where: { foo: 'bar', or: { hello: ['world', 'there'] } }
+  });
+
+  t.equal(
+    query[0],
+    'SELECT email, dob FROM "user_data" WHERE foo=$1 AND (hello=$2 OR hello=$3)',
+    'Generate parameterised query'
+  );
+  t.deepEqual(query[1], ['bar', 'world', 'there'], 'Generate values for parameterised query');
+  t.end();
+});
+
 tape('::select - gen. SQL to select from inner join', function (t) {
   var query = sqlGen.select(null, {
     innerJoin: {

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -49,3 +49,35 @@ test('::shallowCopy', function (t) {
 
   t.end();
 });
+
+test('::nestedValues', function (t) {
+  var obj = {
+    a: ['d', 'e'],
+    b: 'f',
+    c: ['g', 'h', 'i']
+  };
+  var values = _.nestedValues(obj);
+
+  t.deepEqual(values, ['d', 'e', 'f', 'g', 'h', 'i'], 'gets values from arrays');
+
+  t.end();
+});
+
+test('::nestedValues with objects', function (t) {
+  var obj = {
+    a: {
+      b: ['h', 'i'],
+      c: {
+        d: 'j',
+        e: ['k', 'l']
+      }
+    },
+    f: ['m'],
+    g: 'n'
+  };
+  var values = _.nestedValues(obj);
+
+  t.deepEqual(values, ['h', 'i', 'j', 'k', 'l', 'm', 'n'], 'gets values from arrays and objects');
+
+  t.end();
+});


### PR DESCRIPTION
Opening a new PR from branch rather than fork (#27), hopefully travis will prefer it  

#24
Allows you to use OR logic in your SELECT queries.
As 'or' is a keyword in postgres, you can't use it a column name, so you can provide or as a key in a 'where' query to specify multiple values, at least one of which must be true, e.g:
```
where: {
  or: {
    id: 123,
    name: 'Daniel'
  }
}
```
You can also provide an array to specify multiple options for one field:
```
where: {
  or: {
    id: 123,
    name: ['Daniel', 'Jack']
  }
}
```